### PR TITLE
Add Focusable to the SearchDropDown widget

### DIFF
--- a/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/SearchDropDown.java
+++ b/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/SearchDropDown.java
@@ -17,6 +17,7 @@
  */
 package org.vaadin.alump.searchdropdown;
 
+import com.vaadin.event.FieldEvents;
 import com.vaadin.event.MouseEvents;
 import com.vaadin.shared.EventId;
 import com.vaadin.shared.MouseEventDetails;
@@ -37,7 +38,8 @@ import java.util.logging.Logger;
  * Search drop down field
  * @param <T> Type of suggestion values
  */
-public class SearchDropDown<T> extends AbstractField<String> implements SearchSuggestionPresenter<T>, HasValueChangeMode {
+public class SearchDropDown<T> extends AbstractField<String> implements SearchSuggestionPresenter<T>,
+        HasValueChangeMode, FieldEvents.BlurNotifier, FieldEvents.FocusNotifier {
 
     private SearchSuggestionProvider<T> suggestionProvider;
     private List<SearchListener<T>> searchListeners = new ArrayList<>();
@@ -90,6 +92,16 @@ public class SearchDropDown<T> extends AbstractField<String> implements SearchSu
                 SearchEvent<T> event = new SearchEvent<T>(SearchDropDown.this, text, true);
                 searchListeners.forEach(l -> l.search(event));
             }
+        }
+
+        @Override
+        public void focus() {
+            fireEvent(new FieldEvents.FocusEvent(SearchDropDown.this));
+        }
+
+        @Override
+        public void blur() {
+            fireEvent(new FieldEvents.BlurEvent(SearchDropDown.this));
         }
     };
 
@@ -299,5 +311,17 @@ public class SearchDropDown<T> extends AbstractField<String> implements SearchSu
     public void removeClickListener(MouseEvents.ClickListener listener) {
         removeListener(EventId.CLICK_EVENT_IDENTIFIER, MouseEvents.ClickEvent.class,
                 listener);
+    }
+
+    @Override
+    public Registration addBlurListener(FieldEvents.BlurListener listener) {
+        return addListener(FieldEvents.BlurEvent.EVENT_ID, FieldEvents.BlurEvent.class, listener,
+                FieldEvents.BlurListener.blurMethod);
+    }
+
+    @Override
+    public Registration addFocusListener(FieldEvents.FocusListener listener) {
+        return addListener(FieldEvents.FocusEvent.EVENT_ID, FieldEvents.FocusEvent.class, listener,
+                FieldEvents.FocusListener.focusMethod);
     }
 }

--- a/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/client/SearchDropDownConnector.java
+++ b/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/client/SearchDropDownConnector.java
@@ -96,6 +96,7 @@ public class SearchDropDownConnector extends AbstractComponentConnector implemen
 
         getWidget().setSuggestionProvider(this::provideSuggestions);
         getWidget().addSuggestionSelectionListener(this::onSelection);
+        getWidget().setFocusBlurListener(getRpcProxy(SearchDropDownServerRpc.class));
     }
 
     private void onSelection(Integer suggestionId, String text) {

--- a/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/client/SearchDropDownWidget.java
+++ b/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/client/SearchDropDownWidget.java
@@ -29,6 +29,8 @@ import com.vaadin.client.ui.SubPartAware;
 import com.vaadin.client.ui.VOverlay;
 import com.vaadin.client.ui.menubar.MenuBar;
 import com.vaadin.client.ui.menubar.MenuItem;
+import com.vaadin.event.FieldEvents;
+import com.vaadin.shared.communication.FieldRpc;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +50,7 @@ public class SearchDropDownWidget extends Composite implements Focusable {
     private boolean enabled = true;
     private boolean readonly = false;
     private boolean showClear = true;
+    private FieldRpc.FocusAndBlurServerRpc focusBlurListener;
     private SuggestionProvider suggestionProvider;
     private List<SelectionSelectionListener> selectionListeners = new ArrayList<>();
 
@@ -122,6 +125,10 @@ public class SearchDropDownWidget extends Composite implements Focusable {
         selectionListeners.remove(listener);
     }
 
+    public void setFocusBlurListener(FieldRpc.FocusAndBlurServerRpc focusBlurListener) {
+        this.focusBlurListener = focusBlurListener;
+    }
+
     public void setSuggestionProvider(SuggestionProvider provider) {
         suggestionProvider = provider;
     }
@@ -137,10 +144,16 @@ public class SearchDropDownWidget extends Composite implements Focusable {
     private void onBlur(BlurEvent event) {
         removeStyleName("on-focus");
         checkClearVisibility(textField.getValue());
+        if(focusBlurListener != null) {
+            focusBlurListener.blur();
+        }
     }
 
     private void onFocus(FocusEvent event) {
         addStyleName("on-focus");
+        if(focusBlurListener != null) {
+            focusBlurListener.focus();
+        }
     }
 
     private void onKeyUp(KeyUpEvent event) {

--- a/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/client/SearchDropDownWidget.java
+++ b/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/client/SearchDropDownWidget.java
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  * GWT widget implementing search field
  */
-public class SearchDropDownWidget extends Composite {
+public class SearchDropDownWidget extends Composite implements Focusable {
 
     private final FlowPanel panel = new FlowPanel();
 
@@ -417,4 +417,23 @@ public class SearchDropDownWidget extends Composite {
         return iconElement == Element.as(event.getEventTarget());
     }
 
+    @Override
+    public int getTabIndex() {
+        return textField.getTabIndex();
+    }
+
+    @Override
+    public void setAccessKey(char c) {
+        textField.setAccessKey(c);
+    }
+
+    @Override
+    public void setFocus(boolean b) {
+        textField.setFocus(b);
+    }
+
+    @Override
+    public void setTabIndex(int i) {
+        textField.setTabIndex(i);
+    }
 }

--- a/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/client/share/SearchDropDownServerRpc.java
+++ b/searchdropdown-addon/src/main/java/org/vaadin/alump/searchdropdown/client/share/SearchDropDownServerRpc.java
@@ -17,14 +17,14 @@
  */
 package org.vaadin.alump.searchdropdown.client.share;
 
-import com.vaadin.shared.MouseEventDetails;
+import com.vaadin.shared.communication.FieldRpc;
 import com.vaadin.shared.ui.ClickRpc;
 import com.vaadin.shared.ui.textfield.AbstractTextFieldServerRpc;
 
 /**
  * Server RPC for SearchDropDown
  */
-public interface SearchDropDownServerRpc extends AbstractTextFieldServerRpc, ClickRpc {
+public interface SearchDropDownServerRpc extends AbstractTextFieldServerRpc, ClickRpc, FieldRpc.FocusAndBlurServerRpc {
 
     void suggestionSelected(int suggestionId);
 

--- a/searchdropdown-demo/src/main/java/org/vaadin/alump/searchdropdown/demo/DemoUI.java
+++ b/searchdropdown-demo/src/main/java/org/vaadin/alump/searchdropdown/demo/DemoUI.java
@@ -29,6 +29,7 @@ public class DemoUI extends UI {
         navigator.addView(TestView.VIEW_NAME, TestView.class);
         navigator.addView(ExampleView.VIEW_NAME, ExampleView.class);
         navigator.addView(SimpleView.VIEW_NAME, SimpleView.class);
+        navigator.addView(FocusBlurView.VIEW_NAME, FocusBlurView.class);
         navigator.setErrorView(MenuView.class);
         setNavigator(navigator);
     }

--- a/searchdropdown-demo/src/main/java/org/vaadin/alump/searchdropdown/demo/FocusBlurView.java
+++ b/searchdropdown-demo/src/main/java/org/vaadin/alump/searchdropdown/demo/FocusBlurView.java
@@ -1,0 +1,84 @@
+package org.vaadin.alump.searchdropdown.demo;
+
+import com.vaadin.navigator.Navigator;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.Notification;
+import com.vaadin.ui.VerticalLayout;
+import org.vaadin.alump.searchdropdown.SimpleSearchDropDown;
+import org.vaadin.alump.searchdropdown.SimpleSuggestionProvider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+/**
+ * View that shows the use of focus, blur and tabIndex
+ */
+public class FocusBlurView extends VerticalLayout implements View {
+    public final static String VIEW_NAME = "focus-blur";
+    private Navigator navigator;
+
+    public static final String VALUES[] = { "alfa", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+            "india", "juliett", "kilo", "lima", "mike", "november", "oscar", "papa", "quebec", "romea", "sierra",
+            "tango", "uniform", "victor", "whiskey", "xray", "yankee", "zulu" };
+
+    public FocusBlurView() {
+        setWidth(100, Unit.PERCENTAGE);
+        setMargin(true);
+        setSpacing(true);
+
+        SimpleSearchDropDown simpleSearch = new SimpleSearchDropDown(provider);
+
+        addComponent(new MenuButton(e -> navigator.navigateTo(MenuView.VIEW_NAME)));
+
+        addComponent(new Label("Select the desired tab index"));
+        // The tab index decides in which order an element will be focused when using the Tab key
+        // -1 = not focused, 0 = default order, otherwise according to tab index
+        HorizontalLayout tabIndexButtonWrapper = new HorizontalLayout();
+        tabIndexButtonWrapper.addComponent(new Button("-1", e -> {
+            simpleSearch.setTabIndex(-1);
+        }));
+        tabIndexButtonWrapper.addComponent(new Button("0", e -> {
+            simpleSearch.setTabIndex(0);
+        }));
+        tabIndexButtonWrapper.addComponent(new Button("1", e -> {
+            simpleSearch.setTabIndex(1);
+        }));
+        addComponent(tabIndexButtonWrapper);
+
+        // Button for focusing
+        addComponent(new Label("Press to focus"));
+        addComponent(new Button("Focus", e -> {
+            simpleSearch.focus();
+        }));
+
+        // Notifications on focus
+        simpleSearch.addFocusListener(e -> Notification.show("Focused! "));
+        simpleSearch.addBlurListener(e -> Notification.show("Blurred!"));
+
+        simpleSearch.setWidth(500, Unit.PIXELS);
+        simpleSearch.setPlaceHolder("Search Phonetic Alphabets");
+        addComponent(simpleSearch);
+    }
+
+    SimpleSuggestionProvider provider = (query) -> {
+        // For empty query, do not provide any suggestions
+        final String cleaned = query.toLowerCase().trim();
+        if(cleaned.isEmpty()) {
+            return Collections.EMPTY_LIST;
+        }
+
+        // Normally here you would perform database or REST query or queries, to find suitable suggestions.
+        // Simple API is always synchronous, so when you want to go to asynchronous use base class.
+        return Arrays.stream(VALUES).filter(v -> v.contains(cleaned)).collect(Collectors.toList());
+    };
+
+    @Override
+    public void enter(ViewChangeListener.ViewChangeEvent event) {
+        navigator = event.getNavigator();
+    }
+}

--- a/searchdropdown-demo/src/main/java/org/vaadin/alump/searchdropdown/demo/MenuView.java
+++ b/searchdropdown-demo/src/main/java/org/vaadin/alump/searchdropdown/demo/MenuView.java
@@ -30,7 +30,7 @@ public class MenuView extends VerticalLayout implements View {
         addComponent(new Button("Example View", e -> navigator.navigateTo(ExampleView.VIEW_NAME)));
         addComponent(new Button("Simple Example View", e -> navigator.navigateTo(SimpleView.VIEW_NAME)));
         addComponent(new Button("Testing View", e -> navigator.navigateTo(TestView.VIEW_NAME)));
-
+        addComponent(new Button( "Focus and blur view", e -> navigator.navigateTo(FocusBlurView.VIEW_NAME)));
         addComponent(new GitHubLink());
 
     }


### PR DESCRIPTION
This enables the use of `dropdown.setFocus()` from server-side, which did not previously work.

With this implementation, all Focusable-functions are delegated to the search field. I tested `focus()` and `setTabIndex()` which both worked.